### PR TITLE
Support stand by mode in the base daemon.

### DIFF
--- a/microcosm_daemon/daemon.py
+++ b/microcosm_daemon/daemon.py
@@ -78,6 +78,10 @@ class Daemon(object):
         """
         return None
 
+    @property
+    def initial_state(self):
+        return self
+
     @abstractmethod
     def __call__(self, graph):
         """
@@ -120,7 +124,7 @@ class Daemon(object):
         self.graph = self.create_object_graph(self.args)
 
     def run_state_machine(self):
-        state_machine = StateMachine(self.graph, self)
+        state_machine = StateMachine(self.graph, self.initial_state)
         state_machine.run()
 
     def make_arg_parser(self):

--- a/microcosm_daemon/standby.py
+++ b/microcosm_daemon/standby.py
@@ -1,0 +1,77 @@
+"""
+Standby state machine.
+
+"""
+from abc import ABCMeta, abstractproperty
+from six import add_metaclass
+
+from microcosm_daemon.sleep_policy import SleepNow
+
+
+class StandByGuard(object):
+    """
+    State wrapper for a standby-enabled daemon.
+
+    Calls state and then checks condition.
+
+    """
+    def __init__(self, next_state, condition):
+        self.next_state = next_state
+        self.condition = condition
+
+    def __call__(self, graph):
+        """
+        Invoke the wrapped state and then check the standby condition.
+
+        """
+        result = self.next_state(graph)
+
+        should_standby = self.condition(graph)
+        if should_standby:
+            return StandByState(result or self.next_state, self.condition)
+
+        return StandByGuard(result, self.condition)
+
+
+class StandByState(object):
+    """
+    State for a daemon that is in standby.
+
+    Remains in standby until condition is met.
+
+    """
+    def __init__(self, next_state, condition):
+        self.next_state = next_state
+        self.condition = condition
+
+    def __call__(self, graph):
+        """
+        Check the standby condition before advancing to the next state.
+
+        """
+        should_standby = self.condition(graph)
+        if should_standby:
+            raise SleepNow(None)
+
+        return StandByGuard(self.next_state, self.condition)
+
+
+@add_metaclass(ABCMeta)
+class StandByMixin(object):
+    """
+    Mixin for a daemon to inject standby logic.
+
+    """
+    @abstractproperty
+    def standby_condition(self):
+        """
+        Define a stand by condition.
+
+        Should return a function that takes a graph and returns boolean.
+
+        """
+        pass
+
+    @property
+    def initial_state(self):
+        return StandByState(self, self.standby_condition)

--- a/microcosm_daemon/state_machine.py
+++ b/microcosm_daemon/state_machine.py
@@ -10,7 +10,6 @@ class StateMachine(object):
     A state machine for driving daemon processing.
 
     """
-
     def __init__(self, graph, initial_state, never_reload=False):
         self.graph = graph
         self.current_state = initial_state
@@ -33,6 +32,14 @@ class StateMachine(object):
             # stay in the same state
             return self.current_state
 
+    def advance(self):
+        """
+        Advance once step.
+
+        """
+        self.current_state = self.step()
+        return self.current_state
+
     def should_run(self):
         """
         Should the state machine keep running?
@@ -51,7 +58,7 @@ class StateMachine(object):
         try:
             with self.graph.signal_handler:
                 while self.should_run():
-                    self.current_state = self.step()
+                    self.advance()
                     if self.reloader:
                         self.reloader()
         except Exception:

--- a/microcosm_daemon/tests/test_standby.py
+++ b/microcosm_daemon/tests/test_standby.py
@@ -1,0 +1,94 @@
+"""
+Standby state tests.
+
+"""
+from hamcrest import assert_that, equal_to, is_, instance_of
+from mock import MagicMock
+
+from microcosm.api import create_object_graph
+from microcosm_daemon.daemon import Daemon
+from microcosm_daemon.standby import StandByGuard, StandByMixin, StandByState
+from microcosm_daemon.state_machine import StateMachine
+
+
+def make_alternating_condition():
+    """
+    Create a function that simulates a standby condition that alternates.
+
+    """
+    condition = MagicMock()
+    condition.side_effect = [
+        True,
+        False,
+        True,
+        False,
+    ]
+    return condition
+
+
+def example_non_standby_state(graph):
+    """
+    Example of a non-standby state.
+
+    """
+    pass
+
+
+class StandByDaemon(StandByMixin, Daemon):
+    """
+    Example of a daemon that supports standby.
+
+    """
+    @property
+    def name(self):
+        return "test"
+
+    @property
+    def standby_condition(self):
+        return make_alternating_condition()
+
+    def __call__(self, graph):
+        pass
+
+
+def assert_that_states_alternate(state_machine, non_standby_state):
+    """
+    Assert that a state machine alternates states.
+
+    """
+    next_state = state_machine.advance()
+    assert_that(next_state, is_(instance_of(StandByState)))
+    assert_that(next_state.next_state, is_(equal_to(non_standby_state)))
+
+    next_state = state_machine.advance()
+    assert_that(next_state, is_(instance_of(StandByGuard)))
+    assert_that(next_state.next_state, is_(equal_to(non_standby_state)))
+
+    next_state = state_machine.advance()
+    assert_that(next_state, is_(instance_of(StandByState)))
+    assert_that(next_state.next_state, is_(equal_to(non_standby_state)))
+
+    next_state = state_machine.advance()
+    assert_that(next_state, is_(instance_of(StandByGuard)))
+    assert_that(next_state.next_state, is_(equal_to(non_standby_state)))
+
+
+def test_standby():
+    """
+    StandBy state with alternating condition should alternate.
+
+    """
+    graph = create_object_graph("test", testing=True)
+    initial_state = StandByState(example_non_standby_state, make_alternating_condition())
+    state_machine = StateMachine(graph, initial_state, never_reload=True)
+    assert_that_states_alternate(state_machine, example_non_standby_state)
+
+
+def test_standby_mixin():
+    """
+    Daemon that uses `StandByMixin` should alternate.
+
+    """
+    daemon = StandByDaemon.create_for_testing()
+    state_machine = StateMachine(daemon.graph, daemon.initial_state)
+    assert_that_states_alternate(state_machine, daemon)


### PR DESCRIPTION
During deployments, we often want to push out a new daemon while an earlier
version is still running. In this case, we want the new daemon to start up
in standby mode until we trigger a signal, at which point, we want the old
daemon to enter a stand by mode.

This isn't perfect... the stand by mechanism is still left as an exercise
to the reader (e.g. polling a file) and a true distributed coordination
may require additional states. (See [set partitioner](https://kazoo.readthedocs.io/en/latest/api/recipe/partitioner.html))