### PR TITLE
Add typing for non-string config

### DIFF
--- a/microcosm_daemon/error_policy.py
+++ b/microcosm_daemon/error_policy.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from time import time
 
 from microcosm.api import defaults
+from microcosm.config.validation import typed
 
 
 # nagios style health codes
@@ -108,7 +109,7 @@ class ErrorPolicy:
 
 @defaults(
     strict=False,
-    health_report_interval=3.0,
+    health_report_interval=typed(float, 3.0),
 )
 def configure_error_policy(graph):
     return ErrorPolicy(

--- a/microcosm_daemon/sleep_policy.py
+++ b/microcosm_daemon/sleep_policy.py
@@ -5,6 +5,7 @@ Sleep policy.
 from time import sleep
 
 from microcosm.api import defaults
+from microcosm.config.validation import typed
 from microcosm_logging.decorators import logger
 
 
@@ -40,7 +41,7 @@ class SleepPolicy:
 
 
 @defaults(
-    default_sleep_timeout=0.5,
+    default_sleep_timeout=typed(float, 0.5),
 )
 def configure_sleep_policy(graph):
     return SleepPolicy(


### PR DESCRIPTION
- add typing for `health_report_interval`
- add typing for `default_sleep_timeout`

Why?

Makes it so you can override the default value via env vars. Config overridden by env vars are `str`'s otherwise.

Fixes -

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/microcosm_daemon/state_machine.py", line 26, in step
    next_state = self.current_state(self.graph)
  File "/usr/local/lib/python3.9/site-packages/microcosm_daemon/sleep_policy.py", line 38, in __exit__
    self.sleep(value.sleep_timeout or self.default_sleep_timeout)
  File "/usr/local/lib/python3.9/site-packages/microcosm_daemon/sleep_policy.py", line 31, in sleep
    sleep(sleep_timeout)
TypeError: an integer is required (got type str)
```