### PR TITLE
Bump waitress to >=2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
             "PyHamcrest>=1.8.5",
         ],
         "healthcheck": [
-            "waitress>=2.0.0",
+            "waitress>=2.1.1",
             "Flask<2",
             "Flask>=1.0.2",
             "requests>=2.27.1",


### PR DESCRIPTION
* NB: I haven't confirmed any useful exploit from this issue but that's
  probably due to our very limited use as a healthcheck server here.
  Better to patch it then have the potential risk lurking
* Addresses HTTP smuggling vulnerabilities
* CVE-2022-24761
* https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36