### PR TITLE
Log message on unhealthy daemon

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.4.0
 commit = False
 tag = False
 

--- a/microcosm_daemon/healthcheck_server.py
+++ b/microcosm_daemon/healthcheck_server.py
@@ -18,6 +18,7 @@ def create_app(processes: int, heartbeat_threshold_seconds: int):
     @healthcheck_app.route("/api/health")
     def healthcheck():
         if not heartbeats:
+            logger.warning("Daemon has no heartbeat. Healthcheck status: UNHEALTHY")
             return {}, 500
 
         ts = now()
@@ -34,6 +35,9 @@ def create_app(processes: int, heartbeat_threshold_seconds: int):
             else 500
         )
 
+        if status != 200:
+            logger.warning("Healthcheck heartbeat status: UNHEALTHY")
+        logger.debug("Healthcheck heartbeat status: HEALTHY")
         return jsonify(
             heartbeats=last_heartbeats,
         ), status

--- a/microcosm_daemon/healthcheck_server.py
+++ b/microcosm_daemon/healthcheck_server.py
@@ -36,7 +36,7 @@ def create_app(processes: int, heartbeat_threshold_seconds: int):
         )
 
         if status != 200:
-            logger.warning("Healthcheck heartbeat status: UNHEALTHY")
+            logger.warning(f"Healthcheck heartbeat status: UNHEALTHY. Heartbeat values: {heartbeats}")
         logger.debug("Healthcheck heartbeat status: HEALTHY")
         return jsonify(
             heartbeats=last_heartbeats,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
             "waitress>=2.0.0",
             "Flask<2",
             "Flask>=1.0.2",
+            # Due to https://github.com/pallets/jinja/issues/1585
+            "markupsafe<2.1",
             "requests>=2.27.1",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-daemon"
-version = "1.3.0"
+version = "1.4.0"
 
 setup(
     name=project,


### PR DESCRIPTION
https://globality.atlassian.net/browse/GLOB-66061

### Why?
The daemon `/health` endpoint is not necessarily directly
accessible to the outside world. Logging health status makes it more
visible.

### What?
Log `warning`-level message when daemon is unhealthy based on
heartbeat age.