### PR TITLE
Allow running a single worker process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = False
 tag = False
 

--- a/microcosm_daemon/daemon.py
+++ b/microcosm_daemon/daemon.py
@@ -113,7 +113,9 @@ class Daemon:
 
         if args.processes < 1:
             parser.error("--processes must be positive")
-        elif args.processes == 1:
+        elif args.processes == 1 and args.heartbeat_threshold_seconds < 0:
+            # If a heartbeat is configured, we'll run with a master-worker setup
+            # Otherwise just run one process overall
             runner = SimpleRunner(self)
         else:
             runner = ProcessRunner(self, **vars(args))

--- a/microcosm_daemon/health_reporter.py
+++ b/microcosm_daemon/health_reporter.py
@@ -51,10 +51,7 @@ class HealthReporter:
                 timeout=self.heartbeat_timeout,
             )
         except Exception as err:
-            logger.debug(
-                "Failed to send heartbeat",
-                extra=dict(error=err)
-            )
+            logger.debug("Failed to send heartbeat", extra=dict(error=err))  # noqa: G200
 
 
 @defaults(

--- a/microcosm_daemon/health_reporter.py
+++ b/microcosm_daemon/health_reporter.py
@@ -35,7 +35,10 @@ class HealthReporter:
             if isinstance(error, ExitError):
                 continue
 
-            logger.warn(f"Caught error during state evaluation: {error}", exc_info=True)
+            logger.exception(
+                "Caught error during state evaluation",
+                extra=dict(error=error),
+            )
 
     def heartbeat(self):
         if requests is None:
@@ -48,7 +51,10 @@ class HealthReporter:
                 timeout=self.heartbeat_timeout,
             )
         except Exception as err:
-            logger.debug(f"Failed to send heartbeat: {err}")
+            logger.debug(
+                "Failed to send heartbeat",
+                extra=dict(error=err)
+            )
 
 
 @defaults(

--- a/microcosm_daemon/healthcheck_server.py
+++ b/microcosm_daemon/healthcheck_server.py
@@ -36,7 +36,10 @@ def create_app(processes: int, heartbeat_threshold_seconds: int):
         )
 
         if status != 200:
-            logger.warning(f"Healthcheck heartbeat status: UNHEALTHY. Heartbeat values: {heartbeats}")
+            logger.warning(
+                "Healthcheck heartbeat status: UNHEALTHY.",
+                extra=dict(heartbeat_values=heartbeats)
+            )
         logger.debug("Healthcheck heartbeat status: HEALTHY")
         return jsonify(
             heartbeats=last_heartbeats,
@@ -50,7 +53,10 @@ def create_app(processes: int, heartbeat_threshold_seconds: int):
         if not pid:
             return {}, 400
         else:
-            logger.debug(f"Received heartbeat from {pid}")
+            logger.debug(
+                "Received heartbeat from {pid}",
+                extra=dict(pid=pid),
+            )
             heartbeats[pid] = now()
             return {}, 201
 

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -79,22 +79,12 @@ if __name__ == "__main__":
     daemon.run()
 
 
-@parameterized([
-    (1,),
-    (2,),
-])
-def test_healtcheck_server(num_processes):
+def test_healthcheck_server(num_processes):
     popen_instance = Popen(
-        f"python microcosm_daemon/tests/test_runner.py --processes {num_processes} --heartbeat-threshold-seconds 2",
+        "python microcosm_daemon/tests/test_runner.py --processes 2 --heartbeat-threshold-seconds 2",
         shell=True,
     )
-    sleep(2)
     resp = get("http://localhost:80/api/health")
     assert_that(resp.status_code, equal_to(200))
-    assert_that(resp.json()["heartbeats"], has_length(num_processes))
+    assert_that(resp.json()["heartbeats"], has_length(2))
     popen_instance.terminate()
-    # Wait for child process to terminate
-    while True:
-        poll_output = popen_instance.poll()
-        if poll_output is None:
-            break

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -79,12 +79,23 @@ if __name__ == "__main__":
     daemon.run()
 
 
-def test_healthcheck_server(num_processes):
+@parameterized([
+    (1,),
+    (2,),
+])
+def test_healtcheck_server(num_processes):
+    sleep(1)
     popen_instance = Popen(
-        "python microcosm_daemon/tests/test_runner.py --processes 2 --heartbeat-threshold-seconds 2",
+        f"python microcosm_daemon/tests/test_runner.py --processes {num_processes} --heartbeat-threshold-seconds 2",
         shell=True,
     )
+    sleep(2)
     resp = get("http://localhost:80/api/health")
     assert_that(resp.status_code, equal_to(200))
-    assert_that(resp.json()["heartbeats"], has_length(2))
+    assert_that(resp.json()["heartbeats"], has_length(num_processes))
     popen_instance.terminate()
+    # Wait for child process to terminate
+    while True:
+        poll_output = popen_instance.poll()
+        if poll_output is None:
+            break

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -91,5 +91,5 @@ def test_healtcheck_server(num_processes):
     sleep(2)
     resp = get("http://localhost:80/api/health")
     assert_that(resp.status_code, equal_to(200))
-    assert_that(resp.json()["heartbeats"], has_length(2))
+    assert_that(resp.json()["heartbeats"], has_length(num_processes))
     popen_instance.terminate()

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -79,23 +79,13 @@ if __name__ == "__main__":
     daemon.run()
 
 
-@parameterized([
-    (1,),
-    (2,),
-])
-def test_healtcheck_server(num_processes):
-    sleep(1)
+def test_healtcheck_server():
     popen_instance = Popen(
-        f"python microcosm_daemon/tests/test_runner.py --processes {num_processes} --heartbeat-threshold-seconds 2",
+        "python microcosm_daemon/tests/test_runner.py --processes 1 --heartbeat-threshold-seconds 2",
         shell=True,
     )
     sleep(2)
     resp = get("http://localhost:80/api/health")
     assert_that(resp.status_code, equal_to(200))
-    assert_that(resp.json()["heartbeats"], has_length(num_processes))
+    assert_that(resp.json()["heartbeats"], has_length(1))
     popen_instance.terminate()
-    # Wait for child process to terminate
-    while True:
-        poll_output = popen_instance.poll()
-        if poll_output is None:
-            break

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -79,10 +79,10 @@ if __name__ == "__main__":
     daemon.run()
 
 
-@parameterized(
+@parameterized([
     (1,),
     (2,),
-)
+])
 def test_healtcheck_server(num_processes):
     popen_instance = Popen(
         f"python microcosm_daemon/tests/test_runner.py --processes {num_processes} --heartbeat-threshold-seconds 2",

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -93,3 +93,8 @@ def test_healtcheck_server(num_processes):
     assert_that(resp.status_code, equal_to(200))
     assert_that(resp.json()["heartbeats"], has_length(num_processes))
     popen_instance.terminate()
+    # Wait for child process to terminate
+    while True:
+        poll_output = popen_instance.poll()
+        if poll_output is None:
+            break

--- a/microcosm_daemon/tests/test_runner.py
+++ b/microcosm_daemon/tests/test_runner.py
@@ -79,9 +79,13 @@ if __name__ == "__main__":
     daemon.run()
 
 
-def test_healtcheck_server():
+@parameterized(
+    (1,),
+    (2,),
+)
+def test_healtcheck_server(num_processes):
     popen_instance = Popen(
-        "python microcosm_daemon/tests/test_runner.py --processes 2 --heartbeat-threshold-seconds 2",
+        f"python microcosm_daemon/tests/test_runner.py --processes {num_processes} --heartbeat-threshold-seconds 2",
         shell=True,
     )
     sleep(2)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-daemon"
-version = "1.4.0"
+version = "1.5.0"
 
 setup(
     name=project,


### PR DESCRIPTION
### Why?
Our daemon running setup today will either:
- Use the `SimpleRunner` (i.e. single process) if `--processes` is equal to 1.
- Use the `ProcessRunner` (i.e. one main process and `n` worker processes) is `--processes` is greater than 1. In that case, `--processes` is the number of worker processes.

This configuration setup doesn't allow running a main-worker setup with a single worker process. The daemon healthcheck implemented in https://github.com/globality-corp/microcosm-daemon/pull/24 relies on the master process to serve a `/health` endpoint, which means that in the current config setup we cannot have a single worker and a healthcheck. This is impractical e.g. when running services locally on Kubernetes, where we need a healthcheck endpoint but also want to reduce process count to reduce the memory footprint.

### What?
- Use a main+worker setup if the heartbeat config is turned on, i.e. if `--heartbeat-threshold-seconds` is greater than 0.
- Use the single-process setup if `--processes` is equal to 1 and the heartbeat config is off. Those are the default settings, so the default behavior remains unchanged.

### Testing
- Tested locally through https://github.com/globality-corp/juvenal/pull/2018.
- Tested on Kubernetes by spinning up https://github.com/globality-corp/juvenal/pull/2018 on a local cluster.